### PR TITLE
chore: capture user buffer always

### DIFF
--- a/ninetyfive.el
+++ b/ninetyfive.el
@@ -104,14 +104,12 @@
   (or (buffer-file-name) "Untitled-1"))
 
 (defun ninetyfive--get-buffer-content ()
-  "Get the content of the last known user-facing buffer."
+  "Get the content of the last known user-facing buffer, or an empty string if unset."
   (if (and ninetyfive--last-buffer
            (buffer-live-p ninetyfive--last-buffer))
       (with-current-buffer ninetyfive--last-buffer
         (buffer-substring-no-properties (point-min) (point-max)))
-    (progn
-      (message "ERROR: last-buffer is not set or dead")
-      "")))
+    "")) ;; return empty
 
 (defun ninetyfive--get-text-to-cursor ()
   "Get text from beginning of buffer to current cursor position."


### PR DESCRIPTION
example below:

https://github.com/user-attachments/assets/7f80fa40-a54e-41c1-9c69-18db186544c5

Before, defining functions would break completions because of minibuffer. 